### PR TITLE
Support quoted `.group` variable

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -15,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -23,28 +24,39 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,4 +38,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/tidysmd.R
+++ b/R/tidysmd.R
@@ -14,11 +14,13 @@
 #' specifications.
 #'
 #' @param .df A data frame
-#' @param .vars Variables for which to calculate SMD
-#' @param .group Grouping variable
+#' @param .vars Variables for which to calculate SMD. Can be unquoted (`x`) or
+#'   quoted (`"x"`).
+#' @param .group Grouping variable. Can be unquoted (`x`) or quoted (`"x"`).
 #' @param .wts Variables to use for weighting the SMD calculation. These can be,
 #'   for instance, propensity score weights or a binary indicator signaling
-#'   whether or not a participant was included in a matching algorithm.
+#'   whether or not a participant was included in a matching algorithm. Can be
+#'   unquoted (`x`) or quoted (`"x"`).
 #' @param include_observed Logical. If using `.wts`, also calculate the
 #'   unweighted SMD?
 #' @param include_unweighted Deprecated. Please use `include_observed`.

--- a/R/tidysmd.R
+++ b/R/tidysmd.R
@@ -54,7 +54,7 @@ tidy_smd <- function(.df, .vars, .group, .wts = NULL, include_observed = TRUE, i
   # check_weights(.wt)
   .df <- dplyr::as_tibble(.df)
   .vars <- enquo(.vars)
-  .group <- enquo(.group)
+  .group <- ensym(.group)
   .wts <- enquo(.wts)
 
   .df <- dplyr::select(.df, !!.vars, !!.group, !!.wts)
@@ -83,7 +83,7 @@ tidy_smd <- function(.df, .vars, .group, .wts = NULL, include_observed = TRUE, i
 }
 
 tidy_observed_smd <- function(.df, .group, .wts, na.rm = FALSE, gref = 1L, std.error = FALSE) {
-  .group <- enquo(.group)
+  .group <- ensym(.group)
   .wts <- enquo(.wts)
 
   # `summarize()` with multiple rows was  deprecated in dplyr 1.1.0
@@ -111,7 +111,7 @@ tidy_observed_smd <- function(.df, .group, .wts, na.rm = FALSE, gref = 1L, std.e
 }
 
 map_tidy_smd <- function(.df, .group, .wts, na.rm = FALSE, gref = 1L, std.error = FALSE) {
-  .group <- enquo(.group)
+  .group <- ensym(.group)
   wt_cols <- enquo(.wts)
   wt_vars <- names(tidyselect::eval_select(wt_cols, .df))
 
@@ -120,7 +120,7 @@ map_tidy_smd <- function(.df, .group, .wts, na.rm = FALSE, gref = 1L, std.error 
 
 
 tidy_weighted_smd <- function(.df, .group, .wts, .all_wts, na.rm = FALSE, gref = 1L, std.error = FALSE) {
-  .group <- enquo(.group)
+  .group <- ensym(.group)
   .all_wts <- enquo(.all_wts)
   force(.wts)
   .wts_sym <- ensym(.wts)

--- a/man/tidy_smd.Rd
+++ b/man/tidy_smd.Rd
@@ -20,13 +20,15 @@ tidy_smd(
 \arguments{
 \item{.df}{A data frame}
 
-\item{.vars}{Variables for which to calculate SMD}
+\item{.vars}{Variables for which to calculate SMD. Can be unquoted (\code{x}) or
+quoted (\code{"x"}).}
 
-\item{.group}{Grouping variable}
+\item{.group}{Grouping variable. Can be unquoted (\code{x}) or quoted (\code{"x"}).}
 
 \item{.wts}{Variables to use for weighting the SMD calculation. These can be,
 for instance, propensity score weights or a binary indicator signaling
-whether or not a participant was included in a matching algorithm.}
+whether or not a participant was included in a matching algorithm. Can be
+unquoted (\code{x}) or quoted (\code{"x"}).}
 
 \item{include_observed}{Logical. If using \code{.wts}, also calculate the
 unweighted SMD?}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,2 +1,3 @@
 # do work with `psw` objects correctly
+rlang::check_installed("propensity", reason = "to run tests.")
 library(propensity)

--- a/tests/testthat/test-tidysmd.R
+++ b/tests/testthat/test-tidysmd.R
@@ -397,3 +397,14 @@ test_that("tidy_smd() works with `make_dummy_vars = TRUE`", {
 
   expect_tidy_smd_tbl(.smds, .rows = 12)
 })
+
+test_that("tidy_smd() works with quoted variables", {
+  .smds <- tidy_smd(
+    nhefs_weights,
+    c("age", "race", "education"),
+    .group = "qsmk",
+    .wts = "w_ate"
+  )
+
+  expect_tidy_smd_tbl(.smds, .rows = 6)
+})


### PR DESCRIPTION
Closes #15 
Closes #17 

This PR changes the way `tidy_smd()` processes `.group` to let it be a string. Strings already work for the other two arguments because they are supported in dplyr, but for `smd::smd()`, `.group` was turning into a string (the name of the variable. To support both bare names and characters of column names, we now process it with `rlang::ensym()`

Lucy's example now works: 

``` r
library(tidysmd)
tidy_smd(mtcars, .vars = "qsec", .group = "am")
#> # A tibble: 1 × 4
#>   variable method   am      smd
#>   <chr>    <chr>    <chr> <dbl>
#> 1 qsec     observed 1     0.480
```

<sup>Created on 2025-04-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Edit: it also updates `test-coverage.yaml`, which is unrelated to the fix here and does not need to be reviewed.